### PR TITLE
Fix failing HTTP download

### DIFF
--- a/bin/steps/conda_compile
+++ b/bin/steps/conda_compile
@@ -2,7 +2,7 @@
 CONDA_VERSION=3.8.3
 if [ ! -d /app/.heroku/miniconda ]; then
     puts-step "Preparing Python/Miniconda Environment (${CONDA_VERSION})"
-    curl -Os http://repo.continuum.io/miniconda/Miniconda-${CONDA_VERSION}-Linux-x86_64.sh
+    curl -Os https://repo.continuum.io/miniconda/Miniconda-${CONDA_VERSION}-Linux-x86_64.sh
     bash Miniconda-${CONDA_VERSION}-Linux-x86_64.sh -p /app/.heroku/miniconda/ -b | indent
     rm -fr Miniconda-${CONDA_VERSION}-Linux-x86_64.sh
 


### PR DESCRIPTION
Seems like `repo.continuum.io` requires HTTPS now.